### PR TITLE
Fix README run command and newline issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Uses Docker to containerize the application.
 1. **Start the bot**
 
    ```bash
-   python new_discord_bot.py
+   python main.py
    ```
 
 2. **Chat with the bot**
@@ -150,4 +150,4 @@ Uses Docker to containerize the application.
 - **Chat (slash command)**: `/chat message:What's the capital of France?`
 - **Follow-up**: `@BotName And what's interesting to visit there?`
 - **Generate image**: `/imagine prompt:a futuristic city with flying cars`
-- **Reset conversation**: `/clear_context` 
+- **Reset conversation**: `/clear_context`

--- a/main.py
+++ b/main.py
@@ -535,4 +535,4 @@ if __name__ == "__main__":
     except discord.errors.LoginFailure:
         print("ERROR: Invalid Discord Token. Please check your .env file.")
     except Exception as e:
-        print(f"Unexpected error: {e}") 
+        print(f"Unexpected error: {e}")


### PR DESCRIPTION
## Summary
- fix README run command reference
- ensure README and main.py end with newlines

## Testing
- `python3 -m py_compile main.py`
- `pip install -r requirements.txt`
- `python3 main.py` *(fails: missing env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68407e6789dc832a8ed28223f2c97a06