### PR TITLE
Add customizable tone feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Uses Docker to containerize the application.
 - Mention the bot or use `/chat` to chat with the AI
 - Use `!imagine` or `/imagine` to generate images
 - Use `!clear_context` or `/clear_context` to reset chat history
+- Use `/tone` to change the bot's response tone per server
 
 ## Features
 
@@ -66,6 +67,7 @@ Uses Docker to containerize the application.
 - **Command-based interaction**: Traditional commands with the "!" prefix
 - **Image generation**: Create images from text descriptions
 - **Context management**: Maintains separate conversation history for each user
+- **Customizable tone**: Adjust the bot's style from flattering to formal
 
 ## Setup
 
@@ -133,6 +135,7 @@ Uses Docker to containerize the application.
    - `/chat [message]`: Chat with the AI
    - `/imagine [prompt]`: Generate an image from a description
    - `/clear_context`: Clear your conversation history
+   - `/tone`: Choose how formal or flattering the bot should be
 
    **Traditional Commands:**
    - `!clear_context` (aliases: `!cc`, `!reset`): Clear your conversation history

--- a/tone.py
+++ b/tone.py
@@ -1,0 +1,46 @@
+class PromptBase:
+    base_instruction = "Bạn là trợ lý AI nói tiếng Việt. Hãy trả lời ngắn gọn và hữu ích."
+    def get_prompt(self) -> str:
+        return f"{self.base_instruction}\n{self.tone_instruction()}"
+    def tone_instruction(self) -> str:
+        return ""
+
+class VeryFlatteryPrompt(PromptBase):
+    def tone_instruction(self) -> str:
+        return "Bạn phải hết sức nịnh nọt, khen ngợi người dùng bằng lời lẽ nhiệt tình thái quá."
+
+class FlatteryPrompt(PromptBase):
+    def tone_instruction(self) -> str:
+        return "Bạn nên khen ngợi nhẹ nhàng và giữ thái độ tích cực."
+
+class NeuterPrompt(PromptBase):
+    def tone_instruction(self) -> str:
+        return "Bạn trả lời trung tính, không bộc lộ cảm xúc."
+
+class ElegantPrompt(PromptBase):
+    def tone_instruction(self) -> str:
+        return "Bạn trả lời lịch thiệp, tinh tế và có tính thẩm mỹ."
+
+class NoblePrompt(PromptBase):
+    def tone_instruction(self) -> str:
+        return "Bạn sử dụng phong cách trang trọng và triết lý cao quý."
+
+tone_strategies = {
+    1: VeryFlatteryPrompt(),
+    2: FlatteryPrompt(),
+    3: NeuterPrompt(),
+    4: ElegantPrompt(),
+    5: NoblePrompt(),
+}
+
+tone_names = {
+    1: "Very Flattery",
+    2: "Flattery",
+    3: "Neuter",
+    4: "Elegant",
+    5: "Noble",
+}
+
+def get_prompt(level: int) -> str:
+    strategy = tone_strategies.get(level, NeuterPrompt())
+    return strategy.get_prompt()


### PR DESCRIPTION
## Summary
- implement tone strategies for chat responses
- add `/tone` command for admins to pick a style
- generate system prompt per server tone
- document tone command in README

## Testing
- `python -m py_compile main.py tone.py`


------
https://chatgpt.com/codex/tasks/task_e_6840800bb9c8832a943741a20fd39cd0